### PR TITLE
Add AI Weekly to blogs and newsletters

### DIFF
--- a/RESOURCES.md
+++ b/RESOURCES.md
@@ -118,6 +118,7 @@ A curated collection of resources for the GenAI Test Architect journey, organize
 ## Community Resources
 
 ### Blogs & Newsletters
+- [AI Weekly](https://aiweekly.co/) (models, agents, research, and policy ranked from what AI experts read and share)
 - [Confident AI Blog](https://www.confident-ai.com/blog) (DeepEval, LLM testing)
 - [LangChain Blog](https://blog.langchain.dev/) (agents, LangGraph)
 - [Anthropic Research Blog](https://www.anthropic.com/research)


### PR DESCRIPTION
## Summary

Adds [AI Weekly](https://aiweekly.co/) to the Blogs & Newsletters resources. Its frequent coverage helps testing practitioners track model, agent, research, policy, and security changes that can affect GenAI systems.

## Verification

- Canonical URL and public issue archive were checked on 2026-09-05.
- The entry follows the surrounding format and makes no unsupported ranking or performance claims.

## Disclosure

I am the founder of AI Weekly and am proposing my own publication. An AI assistant helped identify the section, prepare the change, and submit this PR; I reviewed the wording and the cited public pages.